### PR TITLE
Set Public IP api-version to 2020-08-01

### DIFF
--- a/snippets/arm-templates/deployments/prerequisites/azdeploy.json
+++ b/snippets/arm-templates/deployments/prerequisites/azdeploy.json
@@ -52,7 +52,7 @@
     "resources": [
         {
             "type": "Microsoft.Network/publicIPAddresses",
-            "apiVersion": "2019-02-01",
+            "apiVersion": "2020-08-01",
             "name": "[parameters('publicIPName')]",
             "location": "[parameters('location')]",
             "sku": {

--- a/snippets/arm-templates/deployments/prerequisites/main.bicep
+++ b/snippets/arm-templates/deployments/prerequisites/main.bicep
@@ -19,7 +19,7 @@ param subnetName string = 'mySubnet'
 @description('Address prefix to use for subnet')
 param subnetAddressPrefix string
 
-resource publicIP 'Microsoft.Network/publicIPAddresses@2019-02-01' = {
+resource publicIP 'Microsoft.Network/publicIPAddresses@2020-08-01' = {
   name: publicIPName
   location: location
   sku: {


### PR DESCRIPTION
per the docs the default for API versions older than 2020-08-01 is to create public IPs that are zone redundant. We do not want those for the sake of simplicity in our scripts.

```
For API versions older than 2020-08-01, use the code above without specifying a zone parameter for a Standard SKU to create a zone-redundant IP address.
```