### PR TITLE
Remove the optional key 'managed_resource_group'

### DIFF
--- a/snippets/terraform/certificates/main.tf
+++ b/snippets/terraform/certificates/main.tf
@@ -103,7 +103,6 @@ resource "azurerm_nginx_deployment" "example" {
   resource_group_name      = module.prerequisites.resource_group_name
   sku                      = var.sku
   location                 = var.location
-  managed_resource_group   = "example"
   diagnose_support_enabled = false
 
   identity {

--- a/snippets/terraform/configurations/main.tf
+++ b/snippets/terraform/configurations/main.tf
@@ -24,7 +24,6 @@ resource "azurerm_nginx_deployment" "example" {
   resource_group_name      = module.prerequisites.resource_group_name
   sku                      = var.sku
   location                 = var.location
-  managed_resource_group   = "example"
   diagnose_support_enabled = false
 
   identity {

--- a/snippets/terraform/deployments/create-or-update/main.tf
+++ b/snippets/terraform/deployments/create-or-update/main.tf
@@ -24,7 +24,6 @@ resource "azurerm_nginx_deployment" "example" {
   resource_group_name      = module.prerequisites.resource_group_name
   sku                      = var.sku
   location                 = var.location
-  managed_resource_group   = "example"
   diagnose_support_enabled = true
 
   identity {


### PR DESCRIPTION
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/nginx_deployment#managed_resource_group

The above docs show that managed RG is an optional property. Confirmed both scenarios with expected behavior.

(https://github.com/nginxinc/nalb-shared/issues/548#issuecomment-1339721183)