### PR TITLE
nlb-2476: change to NGINXaaS for Azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# NGINX For Azure Snippets
+# NGINXaaS for Azure Snippets
 
-This repository contains code snippets for common [NGINX for Azure](https://docs.nginx.com/nginx-for-azure/) use cases. These snippets can be leveraged in applications or as infrastructure as code and in CI workflows to automate the creation or update of NGINX for Azure deployment resources.
+This repository contains code snippets for common [NGINXaaS for Azure](https://docs.nginx.com/nginxaas/azure/) use cases. These snippets can be leveraged in applications or as infrastructure as code and in CI workflows to automate the creation or update of NGINXaaS for Azure deployment resources.
 
 ### Connecting to Azure
 

--- a/snippets/arm-templates/README.md
+++ b/snippets/arm-templates/README.md
@@ -5,8 +5,8 @@
 
 If you are new to NGINXaaS for Azure:
 
-- [NGINX for Azure Documentation](https://docs.nginx.com/nginx-for-azure/)
-- [Prerequisite Documentation](https://docs.nginx.com/nginx-for-azure/quickstart/prerequisites/)
+- [NGINXaaS for Azure Documentation](https://docs.nginx.com/nginxaas/azure/)
+- [Prerequisite Documentation](https://docs.nginx.com/nginxaas/azure/quickstart/prerequisites/)
 
 If you are new to template deployment, see:
 

--- a/snippets/arm-templates/certificates/create-or-update/README.md
+++ b/snippets/arm-templates/certificates/create-or-update/README.md
@@ -1,14 +1,14 @@
 ---
-description: Create or update an NGINX for Azure certificate for a NGINX deployment using an existing certificate in an Azure Key Vault.
+description: Create or update an NGINXaaS for Azure certificate for a NGINX deployment using an existing certificate in an Azure Key Vault.
 languages:
 - json
 - bicep
 ---
 
-# Add an NGINX for Azure deployment certificate.
+# Add an NGINXaaS for Azure deployment certificate.
 
 ## Prerequisites
-- [NGINX documentation](https://docs.nginx.com/nginx-for-azure/management/ssl-tls-certificates/)
+- [NGINX documentation](https://docs.nginx.com/nginxaas/azure/management/ssl-tls-certificates/)
     - [Deployment with user assigned managed identity quickstart template](../../deployments/with-userassigned-identity/README.md)
     
 ## Usage
@@ -21,9 +21,9 @@ az deployment group create  --name myName  --resource-group myGroup --template-f
 
 This template provides a way to deploy a **NGINX Deployment Certificate** to a **NGINX Deployment**. This service is still in **Public Preview**.
 
-If you're new to **NGINX for Azure**, see:
+If you're new to **NGINXaaS for Azure**, see:
 
-- [NGINX for Azure documentation](https://docs.nginx.com/nginx-for-azure/)
+- [NGINXaaS for Azure documentation](https://docs.nginx.com/nginxaas/azure/)
 
 
 If you're new to **Azure Key Vault**, see:

--- a/snippets/arm-templates/configuration/multi-file/README.md
+++ b/snippets/arm-templates/configuration/multi-file/README.md
@@ -1,11 +1,11 @@
 ---
-description: Create or update an NGINX for Azure deployment configuration using multiple files in a resource group.
+description: Create or update an NGINXaaS for Azure deployment configuration using multiple files in a resource group.
 languages:
 - json
 - bicep
 ---
 
-# Create an NGINX for Azure deployment configuration.
+# Create an NGINXaaS for Azure deployment configuration.
 
 ## Prerequisites
 - Existing NGINX deployment
@@ -33,10 +33,10 @@ az deployment group create --name myName --resource-group myGroup --template-fil
 
 This template provides a way to deploy a **NGINX Deployment Configuration** to a **NGINX Deployment**. This service is still in **Public Preview**.
 
-If you're new to **NGINX for Azure**, see:
+If you're new to **NGINXaaS for Azure**, see:
 
-- [NGINX for Azure documentation](https://docs.nginx.com/nginx-for-azure/)
-- [NGINX for Azure Configuration documentation](https://docs.nginx.com/nginx-for-azure/management/nginx-configuration/)
+- [NGINXaaS for Azure documentation](https://docs.nginx.com/nginxaas/azure/)
+- [NGINXaaS for Azure Configuration documentation](https://docs.nginx.com/nginxaas/azure/management/nginx-configuration/)
 
 If you're new to **NGINX Configurations**, see:
 - [NGINX documentation](https://nginx.org/en/docs/)

--- a/snippets/arm-templates/configuration/single-file/README.md
+++ b/snippets/arm-templates/configuration/single-file/README.md
@@ -1,11 +1,11 @@
 ---
-description: Create or update an NGINX for Azure deployment configuration using a single file in a resource group.
+description: Create or update an NGINXaaS for Azure deployment configuration using a single file in a resource group.
 languages:
 - json
 - bicep
 ---
 
-# Create an NGINX for Azure deployment configuration.
+# Create an NGINXaaS for Azure deployment configuration.
 
 ## Prerequisites
 - Existing NGINX deployment
@@ -21,10 +21,10 @@ az deployment group create --name myName --resource-group myGroup --template-fil
 
 This template provides a way to deploy a **NGINX Deployment Configuration** to a **NGINX Deployment**. This service is still in **Public Preview**.
 
-If you're new to **NGINX for Azure**, see:
+If you're new to **NGINXaaS for Azure**, see:
 
-- [NGINX for Azure documentation](https://docs.nginx.com/nginx-for-azure/)
-- [NGINX for Azure Configuration documentation](https://docs.nginx.com/nginx-for-azure/management/nginx-configuration/)
+- [NGINXaaS for Azure documentation](https://docs.nginx.com/nginxaas/azure/)
+- [NGINXaaS for Azure Configuration documentation](https://docs.nginx.com/nginxaas/azure/management/nginx-configuration/)
 
 If you're new to **NGINX Configurations**, see:
 - [NGINX documentation](https://nginx.org/en/docs/)

--- a/snippets/arm-templates/deployments/create-or-update/README.md
+++ b/snippets/arm-templates/deployments/create-or-update/README.md
@@ -1,11 +1,11 @@
 ---
-description: Create or update an NGINX for Azure deployment in a resource group associated with a public IP address.
+description: Create or update an NGINXaaS for Azure deployment in a resource group associated with a public IP address.
 languages:
 - json
 - bicep
 ---
 
-# Creates an NGINX for Azure deployment.
+# Creates an NGINXaaS for Azure deployment.
 
 ### Usage
 ```
@@ -15,9 +15,9 @@ az deployment group create  --name myName  --resource-group myGroup --template-f
 
 This template provides a way to deploy a **NGINX Deployment** in a **Resource Group**. This service is still in **Public Preview**.
 
-If you're new to **NGINX for Azure**, see:
+If you're new to **NGINXaaS for Azure**, see:
 
-- [NGINX for Azure Documentation](https://docs.nginx.com/nginx-for-azure/)
+- [NGINXaaS for Azure Documentation](https://docs.nginx.com/nginxaas/azure/)
 
 If you're new to template deployment, see:
 

--- a/snippets/arm-templates/deployments/prerequisites/README.md
+++ b/snippets/arm-templates/deployments/prerequisites/README.md
@@ -1,11 +1,11 @@
 ---
-description: Create bare minimum prerequisite resources for an NGINX for Azure deployment.
+description: Create bare minimum prerequisite resources for an NGINXaaS for Azure deployment.
 languages:
 - json
 - bicep
 ---
 
-# Create prerequisite resources for an NGINX for Azure deployment.
+# Create prerequisite resources for an NGINXaaS for Azure deployment.
 
 ### Usage
 ```
@@ -16,10 +16,10 @@ az deployment group create  --name myName  --resource-group myGroup --template-f
 
 This template provides a way to deploy minimum prerequisites for an **NGINX Deployment** in a **Resource Group**.
 
-If you're new to **NGINX for Azure**, see:
+If you're new to **NGINXaaS for Azure**, see:
 
-- [NGINX for Azure Documentation](https://docs.nginx.com/nginx-for-azure/)
-- [Prerequisite Documentation](https://docs.nginx.com/nginx-for-azure/quickstart/prerequisites/)
+- [NGINXaaS for Azure Documentation](https://docs.nginx.com/nginxaas/azure/)
+- [Prerequisite Documentation](https://docs.nginx.com/nginxaas/azure/quickstart/prerequisites/)
 
 If you're new to template deployment, see:
 

--- a/snippets/arm-templates/deployments/with-private-ip/README.md
+++ b/snippets/arm-templates/deployments/with-private-ip/README.md
@@ -1,11 +1,11 @@
 ---
-description: Create or update an NGINX for Azure deployment in a resource group associated with a private IP address.
+description: Create or update an NGINXaaS for Azure deployment in a resource group associated with a private IP address.
 languages:
 - json
 - bicep
 ---
 
-# Creates an NGINX for Azure deployment.
+# Creates an NGINXaaS for Azure deployment.
 
 ### Usage
 ```
@@ -15,9 +15,9 @@ az deployment group create  --name myName  --resource-group myGroup --template-f
 
 This template provides a way to deploy a **NGINX Deployment** in a **Resource Group**. This service is still in **Public Preview**.
 
-If you're new to **NGINX for Azure**, see:
+If you're new to **NGINXaaS for Azure**, see:
 
-- [NGINX for Azure Documentation](https://docs.nginx.com/nginx-for-azure/)
+- [NGINXaaS for Azure Documentation](https://docs.nginx.com/nginxaas/azure/)
 
 If you're new to template deployment, see:
 

--- a/snippets/arm-templates/deployments/with-userassigned-identity/README.md
+++ b/snippets/arm-templates/deployments/with-userassigned-identity/README.md
@@ -1,11 +1,11 @@
 ---
-description: Create or update an NGINX for Azure deployment in a resource group associated with a public IP address.
+description: Create or update an NGINXaaS for Azure deployment in a resource group associated with a public IP address.
 languages:
 - json
 - bicep
 ---
 
-# Create an NGINX for Azure deployment with User Assigned Managed Identity
+# Create an NGINXaaS for Azure deployment with User Assigned Managed Identity
 
 ### Usage
 ```
@@ -15,10 +15,10 @@ az deployment group create  --name myName  --resource-group myGroup --template-f
 
 This template provides a way to deploy a **NGINX Deployment** in a **Resource Group**. This service is still in **Public Preview**.
 
-If you're new to **NGINX for Azure**, see:
+If you're new to **NGINXaaS for Azure**, see:
 
-- [NGINX for Azure Documentation](https://docs.nginx.com/nginx-for-azure/)
-- [NGINX for Azure Managed Identity Documentation](https://docs.nginx.com/nginx-for-azure/management/managed-identity/)
+- [NGINXaaS for Azure Documentation](https://docs.nginx.com/nginxaas/azure/)
+- [NGINXaaS for Azure Managed Identity Documentation](https://docs.nginx.com/nginxaas/azure/management/managed-identity/)
 
 If you're new to **Managed Identities**, see:
 


### PR DESCRIPTION
all READMEs are updated to only refer to “NGINXaaS for Azure”, not “NGINX for Azure”

file names, workflow names, and descriptions are updated to refer to “NGINXaaS for Azure”, not “NGINX for Azure”

update docs links with new URL