### PR TITLE
Updated sample of deployment creation with 2023-04-01 API

### DIFF
--- a/snippets/terraform/deployments/create-or-update/main.tf
+++ b/snippets/terraform/deployments/create-or-update/main.tf
@@ -5,11 +5,18 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.57"
     }
+    azapi = {
+      source = "Azure/azapi"
+    }
   }
 }
 
 provider "azurerm" {
   features {}
+}
+
+provider "azapi" {
+
 }
 
 module "prerequisites" {
@@ -19,30 +26,50 @@ module "prerequisites" {
   tags     = var.tags
 }
 
-resource "azurerm_nginx_deployment" "example" {
-  name                     = var.name
-  resource_group_name      = module.prerequisites.resource_group_name
-  sku                      = var.sku
-  location                 = var.location
-  diagnose_support_enabled = true
+# - this relies on making a raw API request, this body we send can be best found at the below URI 
+# https://github.com/Azure/azure-rest-api-specs/blob/5797d78f04cd8ca773be82d2c99a3294009b3f0a/specification/nginx/resource-manager/NGINX.NGINXPLUS/stable/2023-04-01/swagger.json#L1240
+# - for more info on azapi_resource see the below URI
+# https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/azapi_resource
+resource "azapi_resource" "nginx" {
+  type                      = "Nginx.NginxPlus/nginxDeployments@2023-04-01"
+  name                      = var.name
+  parent_id                 = module.prerequisites.resource_group_id
+  location                  = var.location
+  schema_validation_enabled = false
 
   identity {
     type         = "UserAssigned"
     identity_ids = [module.prerequisites.managed_identity_id]
   }
 
-  frontend_public {
-    ip_address = [module.prerequisites.public_ip_address_id]
-  }
-  network_interface {
-    subnet_id = module.prerequisites.subnet_id
-  }
+  body = jsonencode({
+    sku = {
+      name = var.sku
+    }
+    properties = {
+      networkProfile = {
+        frontEndIPConfiguration = {
+          publicIPAddresses = [
+            { id = module.prerequisites.public_ip_address_id }
+          ]
+        }
+        networkInterfaceConfiguration = {
+          subnetId = module.prerequisites.subnet_id
+        }
+      }
+      scalingProperties = {
+        capacity = 10
+      }
+    }
 
-  tags = var.tags
+  })
+
+  tags                   = var.tags
+  response_export_values = ["properties.ipAddress"]
 }
 
 resource "azurerm_role_assignment" "example" {
-  scope                = azurerm_nginx_deployment.example.id
+  scope                = azapi_resource.nginx.id
   role_definition_name = "Monitoring Metrics Publisher"
   principal_id         = module.prerequisites.managed_identity_principal_id
 }

--- a/snippets/terraform/deployments/create-or-update/outputs.tf
+++ b/snippets/terraform/deployments/create-or-update/outputs.tf
@@ -1,4 +1,4 @@
 output "ip_address" {
   description = "IP address of NGINXaaS deployment."
-  value       = azurerm_nginx_deployment.example.ip_address
+  value       = jsondecode(azapi_resource.nginx.output).properties.ipAddress
 }

--- a/snippets/terraform/prerequisites/outputs.tf
+++ b/snippets/terraform/prerequisites/outputs.tf
@@ -3,6 +3,11 @@ output "resource_group_name" {
   value       = azurerm_resource_group.example.name
 }
 
+output "resource_group_id" {
+  description = "ID of the resource group."
+  value       = azurerm_resource_group.example.id
+}
+
 output "managed_identity_id" {
   description = "ID of the managed identity."
   value       = azurerm_user_assigned_identity.example.id


### PR DESCRIPTION
This is a workaround until we can get the provider on the latest API version.

Output of `terraform apply` from within `snippets/terraform/deployment/create-or-update`


![Screenshot 2023-10-13 at 10 47 46 AM](https://github.com/nginxinc/nginxaas-for-azure-snippets/assets/9830221/fd92e7c7-d1e3-4efa-8576-a50e03166b86)

![Screenshot 2023-10-13 at 11 46 12 AM](https://github.com/nginxinc/nginxaas-for-azure-snippets/assets/9830221/3b7307a1-b771-4a24-b2f9-56dc9afe70bf)
