### PR TITLE
Bumped ARM/Bicep templates api-version to 2023-04-01

### DIFF
--- a/snippets/arm-templates/certificates/create-or-update/azdeploy.json
+++ b/snippets/arm-templates/certificates/create-or-update/azdeploy.json
@@ -39,7 +39,7 @@
     "resources": [
         {
             "type": "NGINX.NGINXPLUS/nginxDeployments/certificates",
-            "apiVersion": "2021-05-01-preview",
+            "apiVersion": "2023-04-01",
             "name": "[concat(parameters('nginxDeploymentName'), '/', parameters('certificateName'))]",
             "properties": {
                 "certificateVirtualPath": "[parameters('certificateVirtualPath')]",

--- a/snippets/arm-templates/certificates/create-or-update/main.bicep
+++ b/snippets/arm-templates/certificates/create-or-update/main.bicep
@@ -13,7 +13,7 @@ param keyVirtualPath string = '/etc/ssl/my-cert.key'
 @description('The URI to the AKV secret for the certificate')
 param keyVaultSecretId string
 
-resource certificate 'NGINX.NGINXPLUS/nginxDeployments/certificates@2021-05-01-preview' = {
+resource certificate 'NGINX.NGINXPLUS/nginxDeployments/certificates@2023-04-01' = {
   name: '${nginxDeploymentName}/${certificateName}'
   properties: {
     certificateVirtualPath: certificateVirtualPath

--- a/snippets/arm-templates/configuration/multi-file/azdeploy.json
+++ b/snippets/arm-templates/configuration/multi-file/azdeploy.json
@@ -25,7 +25,7 @@
     "resources": [
         {
             "type": "NGINX.NGINXPLUS/nginxDeployments/configurations",
-            "apiVersion": "2021-05-01-preview",
+            "apiVersion": "2023-04-01",
             "name": "[concat(parameters('nginxDeploymentName'), '/default')]",
             "properties": {
                 "rootFile": "[parameters('rootFile')]",

--- a/snippets/arm-templates/configuration/multi-file/main.bicep
+++ b/snippets/arm-templates/configuration/multi-file/main.bicep
@@ -7,7 +7,7 @@ param rootFile string = '/etc/nginx/nginx.conf'
 @description('The based64 encoded NGINX configuration tarball')
 param tarball string
 
-resource config 'NGINX.NGINXPLUS/nginxDeployments/configurations@2021-05-01-preview' = {
+resource config 'NGINX.NGINXPLUS/nginxDeployments/configurations@2023-04-01' = {
   name: '${nginxDeploymentName}/default'
   properties: {
     rootFile: rootFile

--- a/snippets/arm-templates/configuration/single-file/azdeploy.json
+++ b/snippets/arm-templates/configuration/single-file/azdeploy.json
@@ -26,7 +26,7 @@
     "resources": [
         {
             "type": "NGINX.NGINXPLUS/nginxDeployments/configurations",
-            "apiVersion": "2021-05-01-preview",
+            "apiVersion": "2023-04-01",
             "name": "[concat(parameters('nginxDeploymentName'), '/default')]",
             "properties": {
                 "rootFile": "[parameters('rootConfigFilePath')]",

--- a/snippets/arm-templates/configuration/single-file/main.bicep
+++ b/snippets/arm-templates/configuration/single-file/main.bicep
@@ -7,7 +7,7 @@ param rootConfigFilePath string = 'nginx.conf'
 @description('The based64 encoded content of the root NGINX configuration file')
 param rootConfigContent string
 
-resource config 'NGINX.NGINXPLUS/nginxDeployments/configurations@2021-05-01-preview' = {
+resource config 'NGINX.NGINXPLUS/nginxDeployments/configurations@2023-04-01' = {
   name: '${nginxDeploymentName}/default'
   properties: {
     rootFile: rootConfigFilePath

--- a/snippets/arm-templates/deployments/create-or-update/README.md
+++ b/snippets/arm-templates/deployments/create-or-update/README.md
@@ -10,7 +10,7 @@ languages:
 ### Usage
 ```
 az deployment group create  --name myName  --resource-group myGroup --template-file azdeploy.json \
-    --parameters subnetName=mySubnet virtualNetworkName=myVnet publicIPName=myPublicIP
+    --parameters subnetName=mySubnet virtualNetworkName=myVnet publicIPName=myPublicIP capacity=50
 ```
 
 This template provides a way to deploy a **NGINX Deployment** in a **Resource Group**. This service is still in **Public Preview**.

--- a/snippets/arm-templates/deployments/create-or-update/azdeploy.json
+++ b/snippets/arm-templates/deployments/create-or-update/azdeploy.json
@@ -41,6 +41,13 @@
             "metadata": {
                 "description": "Name of customer virtual network"
             }
+        },
+        "capacity": {
+            "type": "int",
+            "defaultValue": 50,
+            "metadata": {
+                "description": "Capacity in NCUs to assign the NGINX deployment"
+            }
         }
     },
     "resources": [
@@ -61,7 +68,7 @@
         },
         {
             "type": "NGINX.NGINXPLUS/nginxDeployments",
-            "apiVersion": "2021-05-01-preview",
+            "apiVersion": "2023-04-01",
             "name": "[parameters('nginxDeploymentName')]",
             "location": "[parameters('location')]",
             "sku": {
@@ -81,6 +88,9 @@
                     "networkInterfaceConfiguration": {
                         "subnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('subnetName'))]"
                     }
+                },
+                "scalingProperties": {
+                    "capacity": "[parameters('capacity')]"
                 }
             }
         }

--- a/snippets/arm-templates/deployments/create-or-update/azdeploy.parameters.json
+++ b/snippets/arm-templates/deployments/create-or-update/azdeploy.parameters.json
@@ -29,6 +29,10 @@
         "virtualNetworkName": {
             "value": "myVirtualNetwork",
             "type": "string"
+        },
+        "capacity": {
+            "value": 50,
+            "type": "int"
         }
     }
 }

--- a/snippets/arm-templates/deployments/create-or-update/main.bicep
+++ b/snippets/arm-templates/deployments/create-or-update/main.bicep
@@ -16,6 +16,9 @@ param subnetName string
 @description('Name of customer virtual network')
 param virtualNetworkName string
 
+@description('Capacity in NCUs to assign the NGINX deployment')
+param capacity int = 50
+
 resource publicIP 'Microsoft.Network/publicIPAddresses@2020-08-01' = {
   name: publicIPName
   location: location
@@ -31,7 +34,7 @@ resource publicIP 'Microsoft.Network/publicIPAddresses@2020-08-01' = {
   }
 }
 
-resource deployment 'NGINX.NGINXPLUS/nginxDeployments@2021-05-01-preview' = {
+resource deployment 'NGINX.NGINXPLUS/nginxDeployments@2023-04-01' = {
   name: nginxDeploymentName
   location: location
   sku: {
@@ -51,6 +54,9 @@ resource deployment 'NGINX.NGINXPLUS/nginxDeployments@2021-05-01-preview' = {
       networkInterfaceConfiguration: {
         subnetId: resourceId('Microsoft.Network/virtualNetworks/subnets', virtualNetworkName, subnetName)
       }
+    }
+    scalingProperties: {
+      capacity: capacity
     }
   }
 }

--- a/snippets/arm-templates/deployments/with-private-ip/README.md
+++ b/snippets/arm-templates/deployments/with-private-ip/README.md
@@ -10,7 +10,7 @@ languages:
 ### Usage
 ```
 az deployment group create  --name myName  --resource-group myGroup --template-file azdeploy.json \
-    --parameters subnetName=mySubnet virtualNetworkName=myVnet privateIPAddress=10.0.1.4
+    --parameters subnetName=mySubnet virtualNetworkName=myVnet privateIPAddress=10.0.1.4 capacity=50
 ```
 
 This template provides a way to deploy a **NGINX Deployment** in a **Resource Group**. This service is still in **Public Preview**.

--- a/snippets/arm-templates/deployments/with-private-ip/azdeploy.json
+++ b/snippets/arm-templates/deployments/with-private-ip/azdeploy.json
@@ -40,12 +40,19 @@
             "metadata": {
                 "description": "Name of customer virtual network"
             }
+        },
+        "capacity": {
+            "type": "int",
+            "defaultValue": 50,
+            "metadata": {
+                "description": "Capacity in NCUs to assign the NGINX deployment"
+            }
         }
     },
     "resources": [
         {
             "type": "NGINX.NGINXPLUS/nginxDeployments",
-            "apiVersion": "2021-05-01-preview",
+            "apiVersion": "2023-04-01",
             "name": "[parameters('nginxDeploymentName')]",
             "location": "[parameters('location')]",
             "sku": {
@@ -67,6 +74,9 @@
                     "networkInterfaceConfiguration": {
                         "subnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('subnetName'))]"
                     }
+                },
+                "scalingProperties": {
+                    "capacity": "[parameters('capacity')]"
                 }
             }
         }

--- a/snippets/arm-templates/deployments/with-private-ip/azdeploy.parameters.json
+++ b/snippets/arm-templates/deployments/with-private-ip/azdeploy.parameters.json
@@ -25,6 +25,10 @@
         "virtualNetworkName": {
             "value": "myVirtualNetwork",
             "type": "string"
+        },
+        "capacity": {
+            "value": 50,
+            "type": "int"
         }
     }
 }

--- a/snippets/arm-templates/deployments/with-private-ip/main.bicep
+++ b/snippets/arm-templates/deployments/with-private-ip/main.bicep
@@ -16,7 +16,10 @@ param subnetName string
 @description('Name of customer virtual network')
 param virtualNetworkName string
 
-resource deployment 'NGINX.NGINXPLUS/nginxDeployments@2021-05-01-preview' = {
+@description('Capacity in NCUs to assign the NGINX deployment')
+param capacity int = 50
+
+resource deployment 'NGINX.NGINXPLUS/nginxDeployments@2023-04-01' = {
   name: nginxDeploymentName
   location: location
   sku: {
@@ -38,6 +41,9 @@ resource deployment 'NGINX.NGINXPLUS/nginxDeployments@2021-05-01-preview' = {
       networkInterfaceConfiguration: {
         subnetId: resourceId('Microsoft.Network/virtualNetworks/subnets', virtualNetworkName, subnetName)
       }
+    }
+    scalingProperties: {
+      capacity: capacity
     }
   }
 }

--- a/snippets/arm-templates/deployments/with-userassigned-identity/README.md
+++ b/snippets/arm-templates/deployments/with-userassigned-identity/README.md
@@ -10,7 +10,7 @@ languages:
 ### Usage
 ```
 az deployment group create  --name myName  --resource-group myGroup --template-file azdeploy.json \
-    --parameters subnetName=mySubnet virtualNetworkName=myVnet publicIPName=myPublicIP userAssignedIdentityName=myManagedIdentity
+    --parameters subnetName=mySubnet virtualNetworkName=myVnet publicIPName=myPublicIP userAssignedIdentityName=myManagedIdentity capacity=50
 ```
 
 This template provides a way to deploy a **NGINX Deployment** in a **Resource Group**. This service is still in **Public Preview**.

--- a/snippets/arm-templates/deployments/with-userassigned-identity/azdeploy.json
+++ b/snippets/arm-templates/deployments/with-userassigned-identity/azdeploy.json
@@ -55,6 +55,13 @@
             "metadata": {
                 "description": "Enable publishing metrics data from NGINX deployment"
             }
+        },
+        "capacity": {
+            "type": "int",
+            "defaultValue": 50,
+            "metadata": {
+                "description": "Capacity in NCUs to assign the NGINX deployment"
+            }
         }
     },
     "resources": [
@@ -75,7 +82,7 @@
         },
         {
             "type": "NGINX.NGINXPLUS/nginxDeployments",
-            "apiVersion": "2021-05-01-preview",
+            "apiVersion": "2023-04-01",
             "name": "[parameters('nginxDeploymentName')]",
             "location": "[parameters('location')]",
             "sku": {
@@ -101,6 +108,9 @@
                     "networkInterfaceConfiguration": {
                         "subnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('subnetName'))]"
                     }
+                },
+                "scalingProperties": {
+                    "capacity": "[parameters('capacity')]"
                 }
             }
         }

--- a/snippets/arm-templates/deployments/with-userassigned-identity/azdeploy.parameters.json
+++ b/snippets/arm-templates/deployments/with-userassigned-identity/azdeploy.parameters.json
@@ -33,6 +33,10 @@
         "enableMetrics": {
             "value": false,
             "type": "bool"
+        },
+        "capacity": {
+            "value": 50,
+            "type": "int"
         }
     }
 }

--- a/snippets/arm-templates/deployments/with-userassigned-identity/main.bicep
+++ b/snippets/arm-templates/deployments/with-userassigned-identity/main.bicep
@@ -22,6 +22,9 @@ param virtualNetworkName string
 @description('Enable publishing metrics data from NGINX deployment')
 param enableMetrics bool = false
 
+@description('Capacity in NCUs to assign the NGINX deployment')
+param capacity int = 50
+
 resource publicIP 'Microsoft.Network/publicIPAddresses@2020-08-01' = {
   name: publicIPName
   location: location
@@ -37,7 +40,7 @@ resource publicIP 'Microsoft.Network/publicIPAddresses@2020-08-01' = {
   }
 }
 
-resource deployment 'NGINX.NGINXPLUS/nginxDeployments@2021-05-01-preview' = {
+resource deployment 'NGINX.NGINXPLUS/nginxDeployments@2023-04-01' = {
   name: nginxDeploymentName
   location: location
   sku: {
@@ -64,6 +67,9 @@ resource deployment 'NGINX.NGINXPLUS/nginxDeployments@2021-05-01-preview' = {
       networkInterfaceConfiguration: {
         subnetId: resourceId('Microsoft.Network/virtualNetworks/subnets', virtualNetworkName, subnetName)
       }
+    }
+    scalingProperties: {
+      capacity: capacity
     }
   }
 }


### PR DESCRIPTION
Now gives examples of how to configure an NGINXaaS deployment with capacity. Bumps API version to latest. Waiting on generated SDK to update those examples.