### PR TITLE
NLB-4192: Use autoupgradeprofile while creating deployments

### DIFF
--- a/terraform/certificates/main.tf
+++ b/terraform/certificates/main.tf
@@ -134,9 +134,9 @@ resource "azurerm_nginx_certificate" "example" {
   key_virtual_path         = "/etc/nginx/ssl/test.key"
   certificate_virtual_path = "/etc/nginx/ssl/test.crt"
   key_vault_secret_id      = azurerm_key_vault_certificate.example.secret_id
-  
+
   # - ensures deployment has role assignement to fetch certificate
-  depends_on = [ azurerm_role_assignment.example ]
+  depends_on = [azurerm_role_assignment.example]
 }
 
 resource "azurerm_nginx_configuration" "example" {

--- a/terraform/deployments/create-or-update/main.tf
+++ b/terraform/deployments/create-or-update/main.tf
@@ -20,12 +20,13 @@ module "prerequisites" {
 }
 
 resource "azurerm_nginx_deployment" "example" {
-  name                     = var.name
-  resource_group_name      = module.prerequisites.resource_group_name
-  sku                      = var.sku
-  location                 = var.location
-  capacity                 = 20
-  diagnose_support_enabled = true
+  name                      = var.name
+  resource_group_name       = module.prerequisites.resource_group_name
+  sku                       = var.sku
+  location                  = var.location
+  capacity                  = 20
+  automatic_upgrade_channel = "stable"
+  diagnose_support_enabled  = true
 
   identity {
     type         = "UserAssigned"


### PR DESCRIPTION
This commit updates the terraform creation path to include the new auto upgrade profile parameter.

The default behavior if argument is missing is a
`Stable` channel gets picked automatically.