### PR TITLE
Specify capacity in TF examples

### DIFF
--- a/terraform/certificates/main.tf
+++ b/terraform/certificates/main.tf
@@ -94,6 +94,7 @@ resource "azurerm_nginx_deployment" "example" {
   name                     = var.name
   resource_group_name      = module.prerequisites.resource_group_name
   sku                      = var.sku
+  capacity                 = 20
   location                 = var.location
   diagnose_support_enabled = false
 

--- a/terraform/configurations/main.tf
+++ b/terraform/configurations/main.tf
@@ -23,6 +23,7 @@ resource "azurerm_nginx_deployment" "example" {
   name                     = var.name
   resource_group_name      = module.prerequisites.resource_group_name
   sku                      = var.sku
+  capacity                 = 20
   location                 = var.location
   diagnose_support_enabled = false
 


### PR DESCRIPTION
As part of handling the default capacity in
Terraform, we made sure that the user has to
specify scaling properties for SKUs other than the Basic SKU.